### PR TITLE
Fix RSSLink deprecation warning

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -11,4 +11,6 @@
 <link rel="shortcut icon" href="/favicon.ico">
 
 <!-- RSS -->
-<link href="{{ .RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
+{{ with .OutputFormats.Get "rss" -}}
+    {{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}
+{{ end -}}


### PR DESCRIPTION
Fixed the following warning

> Page.RSSLink is deprecated and will be removed in a future release. Use the Output Format's link, e.g. something like:
   ` {{ with .OutputFormats.Get "RSS" }}{{ .RelPermalink }}{{ end }}`

by implementing the standard solution proposed in the documentation [Reference your RSS Feed in `<head>`](https://gohugo.io/templates/rss/#reference-your-rss-feed-in-head).